### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,5 @@
+name        := "lzma"
+description := "An improved version of famous LZ77 compression algorithm."
+homepage    := "http://www.7-zip.org/sdk.html"
+license     := "LGPL-2.0"
+version     := 16.04 sha256:50adee7a4259e3492d8b68dfd12bda0ed27e615193a16f10af296f23dc831b14 http://deb.debian.org/debian/pool/main/p/p7zip/p7zip_16.04+dfsg.orig.tar.xz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

